### PR TITLE
#3 Paging

### DIFF
--- a/src/main/java/jpql/JpaMain.java
+++ b/src/main/java/jpql/JpaMain.java
@@ -13,43 +13,24 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Member member1 = new Member();
-            member1.setAge(24);
-            member1.setUsername("member1");
-            em.persist(member1);
+            for (int i = 0; i < 100; i++) {
 
-            em.createQuery("select m from Member m", Member.class)
-                            .getResultList();
-            em.createQuery("select t from Member m join m.team t")
-                            .getResultList();
-            em.createQuery("select o.address from Order o", Address.class)
-                            .getResultList();
-            List resultList = em.createQuery("select m.username, m.age from Member m")
+                Member member = new Member();
+                member.setAge(i);
+                member.setUsername("member" + i);
+                em.persist(member);
+            }
+
+
+            List<Member> resultList = em.createQuery("select m from Member m order by m.age asc", Member.class)
+                    .setFirstResult(0)
+                    .setMaxResults(10)
                     .getResultList();
 
-            List<Object[]> resultList1 = em.createQuery("select m.username, m.age from Member m")
-                    .getResultList();
+            for (Member member : resultList) {
+                System.out.println(member);
+            }
 
-            List<MemberDTO> resultList2 = em.createQuery("select distinct new jpql.MemberDTO(m.username, m.age) from Member m", MemberDTO.class)
-                    .getResultList();
-
-            Object o = resultList.get(0);
-            Object[] result = (Object[]) o;
-
-            MemberDTO memberDTO = resultList2.get(0);
-            System.out.println(memberDTO.getUsername());
-            System.out.println(memberDTO.getAge());
-
-//            Object[] result1 = resultList1.get(0);
-//            System.out.println(result1[0]);
-//            System.out.println(result1[1]);
-
-//            System.out.println(result[0]);
-//            System.out.println(result[1]);
-//
-//            for (Object o1 : result) {
-//                System.out.println(o1);
-//            }
             tx.commit();
         } catch (Exception e) {
             tx.rollback();

--- a/src/main/java/jpql/Member.java
+++ b/src/main/java/jpql/Member.java
@@ -48,4 +48,13 @@ public class Member {
     public void setTeam(Team team) {
         this.team = team;
     }
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", age=" + age +
+                '}';
+    }
 }


### PR DESCRIPTION
JPA는 페이징을 두 API로 추상화 한다.
 - setFirstResult(int startPosition) : 조회 시작 위치 (0부터 시작)
 - setMaxResults(int maxResult) : 조회할 데이터 수

페이징이란, 우리가 원하는 대로 데이터를 정렬하여 원하는 만큼의 데이터를 받는 것이다. 이걸 그냥 sql문으로 쓰려면 매우 복잡한 경우들이 있다. 예를 들어 oracle DB의 경우 번거롭다.

하지만 JPA에서는
em.createQuery("select m from Member m order by m.age desc(or asc)", Member.class)
.setFirstResult(0)
.setMaxResults(10)
.getResultList();

이런식으로 하면 나이순으로 오름차순 또는 내림차순 한 후에, 앞의 10개 값을 받는 것이다.

또한, JPA는 DB 방언을 갈아낄 수 있기 때문에 persistence.xml 만 변경해주면 쿼리의 변경없이 잘 작동한다.

** 결국 페이징은 데이터를 어디서부터, 몇개 가져올래? 가 핵심이다. 근데 이 단순한 생각을 코드로 작성하려면 oracleDB나 MSSQL 에서는 너무 복잡한 쿼리가 된다. 그래서 JPA를 사용하면 매우매우 간단하게 페이징을 할 수 있다..