### PR TITLE
#5 서브 쿼리, 타입, case 식

### DIFF
--- a/src/main/java/jpql/JpaMain.java
+++ b/src/main/java/jpql/JpaMain.java
@@ -13,23 +13,40 @@ public class JpaMain {
         tx.begin();
 
         try {
-            Team team = new Team();
-            team.setName("teamA");
-            em.persist(team);
-
             Member member = new Member();
             member.setAge(10);
-            member.setUsername("teamA");
-            member.setTeam(team);
-
+            member.setUsername("관리자");
             em.persist(member);
 
             em.flush();
             em.clear();
 
-            List result = em.createQuery("select m from Member m join Team t on m.username = t.name")
+
+            String query = "select " +
+                                "case when m.age <= 10 then '학생요금'" +
+                                "     when m.age >= 60 then '경로요금'" +
+                                     "else '일반요금' end " +
+                           "from Member m";
+            List<String> result = em.createQuery(query, String.class)
                     .getResultList();
-            System.out.println(result.size());
+
+            for (String s : result) {
+                System.out.println(s);
+            }
+
+            String query2 = "select coalesce(m.username, '이름 없는 회원') from Member m";
+            List<String> result2 = em.createQuery(query2, String.class)
+                    .getResultList();
+            for (String s : result2) {
+                System.out.println(s);
+            }
+
+            String query3 = "select nullif(m.username, '관리자') from Member m";
+            List<String> result3 = em.createQuery(query3, String.class)
+                    .getResultList();
+            for (String s : result3) {
+                System.out.println(s);
+            }
 
             tx.commit();
         } catch (Exception e) {


### PR DESCRIPTION
쿼리 내부에서 다른 쿼리를 작성하는 것을 서브 쿼리라고 한다.

예를 들면, 나이가 평균보다 많은 회원을 조회하고 싶을 때
select m from Member m where m.age > (select avg(m2.age) from Member m2) 이런식으로 서브쿼리를 작성한다.
서브쿼리는 같은 Member를 조회하더라도 본 쿼리와 이름을 다르게 쓴다. 이게 성능적으로 좋다고 한다.

JPA 에서 서브쿼리는 where, having 절에서만 사용이 가능하다. hibernate에서 select 절에 서브쿼리 사용을 지원하기 때문에 대부분의 환경에서 가능하다. 하지만, from 절에서의 서브쿼리는 현재 JPQL에서 불가능하다. 되도록 join으로 풀어서 해결하거나, 정 안되면 native sql로 해결한다.

서브쿼리에서 지원하는 함수는 EXISTS, ALL, ANY, SOME, IN 이 있다.
EXISTS는 서브쿼리에 결과가 존재하면 참이다. ALL은 조건을 모두 만족하면 참, ANY와 SOME은 조건을 하나라도 만족하면 참이다. IN은 서브쿼리의 결과 중 하나라도 같은 것이 있으면 참이다.

JPQL의 타입표현으로는 문자는 '' 를 사용하고, ENUM을 쿼리에 직접 사용하고싶은 경우 패키지명을 포함해야 한다. 주로 이렇게 하지는 않고 파라미터 바인딩으로 쓴다.
상속 관계에서는
select I from Item I where type(i) = book 요런 식이 가능하다.

조건식(CASE 식)은 말 그대로 select 절에서 case를 적어주는 것이다. 기본 case식은 when-then, else 형식으로 쓰고 단순 case식은 형식은 같지만 switch 문법과 유사하다.

coalesce : 하나씩 조회해서 null이 아니면 반환
select coalesce (m.username, '이름 없는 회원') from Member m
-> 사용자 이름이 없으면 '이름 없는 회원'을 반환

nullif : 둘의 값이 같으면 null, 다르면 첫 번째 값을 반환
select nullif(m.username, '관리자') from Member m
-> 관리자의 이름을 숨기기 위해 사용.